### PR TITLE
Fix dl_purchase Event Not Firing on APM

### DIFF
--- a/src/utils/analytics/tracking/AutoEventListener.ts
+++ b/src/utils/analytics/tracking/AutoEventListener.ts
@@ -591,6 +591,8 @@ export class AutoEventListener {
 
     this.eventBus.on('order:completed', handleOrderCompleted);
     this.eventHandlers.set('order:completed', handleOrderCompleted);
+    this.eventBus.on('express-checkout:completed', handleOrderCompleted);
+    this.eventHandlers.set('express-checkout:completed', handleOrderCompleted);
   }
 
   /**


### PR DESCRIPTION
Root cause of this bug is not related to field validation.
The issue is that AutoEventListener never registered a listener for the `express-checkout:completed` event. When a user checks out via APM (PayPal / Apple Pay / Google Pay), the flow emits `express-checkout:completed` instead of `order:completed` — so `handleOrderCompleted` was never called, and the `dl_purchase` event was never pushed to the data layer.

<img width="2506" height="1374" alt="image" src="https://github.com/user-attachments/assets/faf1ab3b-1e41-4e84-b4ce-7f1aca78c249" />
