### PR TITLE
Fix SDK test mode activation contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,18 @@ TypeScript SDK for building campaign pages on [NextCommerce](https://nextcommerc
 | E2E tests | `npm run test:e2e` |
 
 See [CLAUDE.md](CLAUDE.md) for architecture overview and contribution guidelines.
+
+## Test Mode API
+
+Automation can enable checkout test mode without synthesizing the Konami key
+sequence:
+
+```js
+document.dispatchEvent(new CustomEvent('next:test-mode-activate', {
+  detail: { method: 'qa-automation', fillCard: true }
+}));
+```
+
+This activates test mode, emits `next:test-mode-activated`, and fills test
+checkout/card fields when requested. It does not create an order or redirect.
+Test orders still require an explicit submit click through the rendered checkout.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -226,10 +226,11 @@ export class ApiClient {
 
       return data;
     } catch (error) {
-      if (error instanceof Error) {
-        this.logger.error('API request failed:', error.message);
+      const message = error instanceof Error ? error.message : String(error);
+      if (isAbortError(error, options?.signal)) {
+        this.logger.debug('API request aborted:', message);
       } else {
-        this.logger.error('API request failed:', String(error));
+        this.logger.error('API request failed:', message);
       }
 
       throw error;
@@ -245,4 +246,10 @@ export class ApiClient {
   public getApiKey(): string {
     return this.apiKey;
   }
+}
+
+function isAbortError(error: unknown, signal?: AbortSignal | null): boolean {
+  if (signal?.aborted) return true;
+  if (!(error instanceof Error)) return false;
+  return error.name === 'AbortError' || /aborted|abort/i.test(error.message);
 }

--- a/src/enhancers/checkout/CheckoutFormEnhancer.ts
+++ b/src/enhancers/checkout/CheckoutFormEnhancer.ts
@@ -3484,7 +3484,7 @@ export class CheckoutFormEnhancer extends BaseEnhancer {
     const customEvent = event as CustomEvent;
     const activationMethod = customEvent.detail?.method;
 
-    if (activationMethod === 'konami') {
+    if (activationMethod) {
       try {
         const testFormData = {
           email: 'test@test.com',
@@ -3540,18 +3540,15 @@ export class CheckoutFormEnhancer extends BaseEnhancer {
 
         this.populateFormData();
 
-        setTimeout(async () => {
-          try {
-            const order = await this.createTestOrder();
-            this.emit('order:completed', order);
-            this.handleOrderRedirect(order);
-          } catch (error) {
-            this.logger.error('Failed to create test order:', error);
-          }
-        }, 1000);
+        document.dispatchEvent(
+          new CustomEvent('next:test-checkout-data-filled', {
+            detail: { method: activationMethod }
+          })
+        );
+        this.logger.info('Test checkout data filled; submit still requires an explicit user or automation action.');
 
       } catch (error) {
-        this.logger.error('Error filling test data for Konami order:', error);
+        this.logger.error('Error filling test data for test mode:', error);
       }
     }
   }

--- a/src/utils/testMode.ts
+++ b/src/utils/testMode.ts
@@ -11,6 +11,14 @@ export interface TestCard {
   type: 'visa' | 'mastercard' | 'amex' | 'discover';
 }
 
+export interface TestModeActivationDetail {
+  method?: string;
+  persist?: boolean;
+  showMessage?: boolean;
+  fillCard?: boolean;
+  cardType?: string;
+}
+
 export class TestModeManager {
   private static instance: TestModeManager;
   private isTestMode = false;
@@ -28,6 +36,8 @@ export class TestModeManager {
   ];
   private keySequence: string[] = [];
   private konamiCallback?: () => void;
+  private boundHandleActivateEvent = this.handleActivateEvent.bind(this);
+  private boundHandleFillCardEvent = this.handleFillCardEvent.bind(this);
 
   private testCards: TestCard[] = [
     {
@@ -69,11 +79,41 @@ export class TestModeManager {
 
   private constructor() {
     this.initializeKonamiCode();
+    this.initializePublicEvents();
     this.checkUrlTestMode();
   }
 
   private initializeKonamiCode(): void {
     document.addEventListener('keydown', this.handleKeyDown.bind(this));
+  }
+
+  private initializePublicEvents(): void {
+    document.addEventListener(
+      'next:test-mode-activate',
+      this.boundHandleActivateEvent as EventListener
+    );
+    document.addEventListener(
+      'next:test-card-fill',
+      this.boundHandleFillCardEvent as EventListener
+    );
+  }
+
+  private handleActivateEvent(event: Event): void {
+    const detail = (event as CustomEvent<TestModeActivationDetail>).detail || {};
+    this.activateTestMode({
+      method: detail.method || 'operator',
+      persist: detail.persist !== false,
+      showMessage: detail.showMessage === true,
+    });
+
+    if (detail.fillCard === true) {
+      this.fillTestCardData(detail.cardType);
+    }
+  }
+
+  private handleFillCardEvent(event: Event): void {
+    const detail = (event as CustomEvent<TestModeActivationDetail>).detail || {};
+    this.fillTestCardData(detail.cardType);
   }
 
   private handleKeyDown(event: KeyboardEvent): void {
@@ -112,13 +152,11 @@ export class TestModeManager {
   private activateKonamiCode(): void {
     console.log('🎮 Konami Code activated!');
 
-    this.isTestMode = true;
-    this.showKonamiMessage();
-
-    // Add URL parameter to maintain test mode
-    const url = new URL(window.location.href);
-    url.searchParams.set('test', 'true');
-    window.history.replaceState({}, '', url.toString());
+    this.activateTestMode({
+      method: 'konami',
+      persist: true,
+      showMessage: true,
+    });
 
     // Call callback if registered
     if (this.konamiCallback) {
@@ -126,11 +164,25 @@ export class TestModeManager {
         this.konamiCallback?.();
       }, 2000);
     }
+  }
 
-    // Emit event
+  public activateTestMode(detail: TestModeActivationDetail = {}): void {
+    const method = detail.method || 'operator';
+    this.isTestMode = true;
+
+    if (detail.showMessage === true) {
+      this.showKonamiMessage();
+    }
+
+    if (detail.persist !== false) {
+      const url = new URL(window.location.href);
+      url.searchParams.set('test', 'true');
+      window.history.replaceState({}, '', url.toString());
+    }
+
     document.dispatchEvent(
       new CustomEvent('next:test-mode-activated', {
-        detail: { method: 'konami' },
+        detail: { method },
       })
     );
   }
@@ -204,9 +256,7 @@ export class TestModeManager {
     this.isTestMode = enabled;
 
     if (enabled) {
-      const url = new URL(window.location.href);
-      url.searchParams.set('test', 'true');
-      window.history.replaceState({}, '', url.toString());
+      this.activateTestMode({ method: 'programmatic', persist: true });
     }
   }
 


### PR DESCRIPTION
## Summary
- add a public next:test-mode-activate event for QA/browser automation
- stop test-mode activation from auto-creating orders or redirecting
- demote expected aborted API requests from error logs to debug logs

## Verification
- npm run type-check
- npm run build

Context: SELL-271 dogfood remediation for test-mode auto-submit and aborted fetch console noise.