### PR TITLE
Add code-specific coupon conditional display

### DIFF
--- a/src/enhancers/display/ConditionalDisplayEnhancer.test.ts
+++ b/src/enhancers/display/ConditionalDisplayEnhancer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { ConditionalDisplayEnhancer } from './ConditionalDisplayEnhancer';
+import { useCartStore } from '@/stores/cartStore';
+
+describe('ConditionalDisplayEnhancer coupon conditions', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    useCartStore.setState({ vouchers: [] });
+  });
+
+  it('shows elements when cart.hasCoupon matches the active coupon code', async () => {
+    useCartStore.setState({ vouchers: ['FREESHIP'] });
+    const element = document.createElement('div');
+    element.setAttribute('data-next-show', 'cart.hasCoupon("FREESHIP")');
+    document.body.appendChild(element);
+
+    const enhancer = new ConditionalDisplayEnhancer(element);
+    await enhancer.initialize();
+
+    expect(element.style.display).toBe('');
+    expect(element.classList.contains('next-visible')).toBe(true);
+  });
+
+  it('hides elements when cart.hasCoupon targets a different coupon code', async () => {
+    useCartStore.setState({ vouchers: ['SAVE10'] });
+    const element = document.createElement('div');
+    element.setAttribute('data-next-show', 'cart.hasCoupon("FREESHIP")');
+    document.body.appendChild(element);
+
+    const enhancer = new ConditionalDisplayEnhancer(element);
+    await enhancer.initialize();
+
+    expect(element.style.display).toBe('none');
+    expect(element.classList.contains('next-hidden')).toBe(true);
+  });
+});

--- a/src/enhancers/display/ConditionalDisplayEnhancer.ts
+++ b/src/enhancers/display/ConditionalDisplayEnhancer.ts
@@ -1044,6 +1044,14 @@ export class ConditionalDisplayEnhancer extends BaseEnhancer {
         
         case 'hasItems':
           return !cartState.isEmpty;
+
+        case 'hasCoupon':
+          if (args.length > 0) {
+            const code = this.normalizeCouponCode(args[0]);
+            if (!code) return false;
+            return (cartState.vouchers ?? []).some(voucher => this.normalizeCouponCode(voucher) === code);
+          }
+          return (cartState.vouchers ?? []).length > 0;
         
         default:
           this.logger.warn(`Unknown cart method: ${method}`);
@@ -1052,6 +1060,14 @@ export class ConditionalDisplayEnhancer extends BaseEnhancer {
     }
     
     return false;
+  }
+
+  private normalizeCouponCode(value: unknown): string {
+    const raw = String(value ?? '').trim();
+    const unquoted = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+      ? raw.slice(1, -1)
+      : raw;
+    return unquoted.trim().toUpperCase();
   }
 
   private evaluateComparison(cartState: CartState, condition: any): boolean {

--- a/src/enhancers/display/README.md
+++ b/src/enhancers/display/README.md
@@ -223,6 +223,7 @@ Shows or hides elements based on conditions evaluated against store state.
 
 <!-- Function call -->
 <div data-next-show="cart.hasItem(123)">You have the basic package</div>
+<div data-next-show='cart.hasCoupon("FREESHIP")'>Free shipping applied</div>
 
 <!-- Profile-based -->
 <div data-next-show-if-profile="wholesale">Wholesale Price</div>


### PR DESCRIPTION
## Summary
- add `cart.hasCoupon("CODE")` conditional display support
- document the helper for offer-specific checkout presentation state
- add focused `ConditionalDisplayEnhancer` coverage

## Why This Exists
Campaigns OS is starting to model a common checkout retention pattern explicitly: when a shopper shows exit intent, the checkout can present a final save offer such as “apply free shipping”, “take an extra 5% off”, or another dynamic voucher-backed offer. If the shopper accepts, the SDK already has the important pricing behavior: the code is applied, bundle selectors recalculate, and order-summary discounts update from Campaigns API / cart calculation truth.

The missing ergonomic piece is presentation state. Templates need a clean way to show code-specific copy only when the mapped coupon/promo code is active, for example:

```html
<span data-next-show='cart.hasCoupon("FREESHIP")'>Free shipping applied</span>
<span data-next-show='cart.hasCoupon("EXIT5")'>Extra 5% off applied</span>
```

Without this, Campaigns OS builders either have to rely on brittle assumptions like `cart.discountCode == "FREESHIP"` being the first/only code, or add campaign-specific JavaScript just to toggle a badge/label after the exit-intent offer is accepted. That is exactly the hand-wiring we are trying to remove from repeated campaign builds.

## Naming
This intentionally uses the existing public SDK vocabulary: `data-next-coupon`, `cart.hasCoupons`, `cart.hasCoupon`, `discountCode`, and `discountCodes`. Internally the state/API may call these `vouchers`, but template authors already see this surface as coupons/promo codes. This PR extends the existing `cart.hasCoupon` token from a boolean presence check to also support a code argument.

## Design Intent
This is intentionally small SDK surface area. It does not introduce Profiles, Retention Offers, or another pricing model. Pricing truth remains in Campaigns API / cart calculation, and this helper only answers: “is this coupon/promo code currently active in cart state?”

## Tests
- `npm test -- ConditionalDisplayEnhancer.test.ts --run`
- `npm run type-check`