### PR TITLE
feat(analytics): export the SDK's dl_* event names as a typed list + JSON manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:window": "tsc && vite build && copy public\\loader.js dist\\",
     "build:cf:window": "vite build && vite build -c vite.config.legacy.ts && npm run build:config && copy public\\loader.js dist\\",
     "build:config": "node scripts/build-config.js",
-    "analytics:manifest": "UPDATE_ANALYTICS_MANIFEST=1 vitest run src/tests/utils/analyticsVocabulary.test.ts",
+    "analytics:manifest": "UPDATE_ANALYTICS_MANIFEST=1 vitest run src/tests/utils/analyticsVocabulary.test.ts; vitest run src/tests/utils/analyticsVocabulary.test.ts",
     "build:dev": "vite build --mode development --watch",
     "preview": "vite preview",
     "test": "vitest",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:window": "tsc && vite build && copy public\\loader.js dist\\",
     "build:cf:window": "vite build && vite build -c vite.config.legacy.ts && npm run build:config && copy public\\loader.js dist\\",
     "build:config": "node scripts/build-config.js",
+    "analytics:manifest": "UPDATE_ANALYTICS_MANIFEST=1 vitest run src/tests/utils/analyticsVocabulary.test.ts",
     "build:dev": "vite build --mode development --watch",
     "preview": "vite preview",
     "test": "vitest",

--- a/src/tests/utils/analyticsVocabulary.test.ts
+++ b/src/tests/utils/analyticsVocabulary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import {
@@ -15,10 +15,40 @@ import { eventSchemas } from '@/utils/analytics/schemas';
 // must stay byte-identical to the DL_EVENTS const. Regenerate after editing the
 // vocabulary with:  UPDATE_ANALYTICS_MANIFEST=1 npm run test -- analyticsVocabulary
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const MANIFEST_PATH = join(
-  __dirname,
-  '../../utils/analytics/schemas/events.manifest.json'
-);
+const ANALYTICS_SRC = join(__dirname, '../../utils/analytics');
+// The vocabulary declaration itself lists every name, so it must be excluded
+// from the emit-site scan below — otherwise a typo'd entry in DL_EVENTS would
+// appear as a literal here and hide from the drift check.
+const SCHEMAS_DIR = join(ANALYTICS_SRC, 'schemas');
+const MANIFEST_PATH = join(SCHEMAS_DIR, 'events.manifest.json');
+
+// Recursively collect the analytics emit-site source files: every .ts under
+// src/utils/analytics EXCEPT the schemas/ vocabulary declaration and test files.
+function collectEmitSiteFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (full === SCHEMAS_DIR) continue;
+      out.push(...collectEmitSiteFiles(full));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Every dl_* string literal emitted anywhere in the analytics source.
+function scanEmittedEventNames(): Set<string> {
+  const found = new Set<string>();
+  for (const file of collectEmitSiteFiles(ANALYTICS_SRC)) {
+    const src = readFileSync(file, 'utf8');
+    for (const m of src.matchAll(/['"](dl_[a-z_]+)['"]/g)) {
+      found.add(m[1]);
+    }
+  }
+  return found;
+}
 
 function buildManifest(): string {
   return (
@@ -64,6 +94,32 @@ describe('analytics dl_* vocabulary (single source of truth)', () => {
     }
   });
 
+  it('vocabulary matches the dl_* events actually emitted in source (both directions)', () => {
+    // Closes the drift class this PR exists to prevent, in BOTH directions:
+    //  • a new dl_* emit added to source (events/, tracking/, providers/) but
+    //    not to DL_EVENTS — the manifest would silently miss it, and a
+    //    blockedEvents picker built from it would too.
+    //  • a typo'd/stale entry in DL_EVENTS that no source site actually emits
+    //    (which the `name: string` type cannot catch on its own).
+    const emitted = scanEmittedEventNames();
+
+    const emittedNotListed = [...emitted]
+      .filter(name => !DL_EVENT_NAME_SET.has(name))
+      .sort();
+    expect(
+      emittedNotListed,
+      `emitted in source but missing from DL_EVENTS: ${emittedNotListed.join(', ')}`
+    ).toEqual([]);
+
+    const listedNotEmitted = DL_EVENT_NAMES.filter(
+      name => !emitted.has(name)
+    ).sort();
+    expect(
+      listedNotEmitted,
+      `in DL_EVENTS but not emitted anywhere in source (typo or stale?): ${listedNotEmitted.join(', ')}`
+    ).toEqual([]);
+  });
+
   it('isKnownDlEvent recognizes vocabulary and rejects unknowns', () => {
     expect(isKnownDlEvent('dl_purchase')).toBe(true);
     expect(isKnownDlEvent('purchase')).toBe(false); // the original drift bug
@@ -73,7 +129,16 @@ describe('analytics dl_* vocabulary (single source of truth)', () => {
   it('committed manifest is in sync with DL_EVENTS', () => {
     const expected = buildManifest();
     if (process.env.UPDATE_ANALYTICS_MANIFEST) {
+      // Regeneration is a deliberate, one-shot action — never a silent side
+      // effect of a passing assertion. Writing then throwing means that if this
+      // env var ever leaks into CI, the run goes RED (drift surfaced) instead of
+      // green-with-a-dirty-tree. The `analytics:manifest` npm script writes here,
+      // then re-runs this test WITHOUT the flag to confirm the tree is clean.
       writeFileSync(MANIFEST_PATH, expected);
+      throw new Error(
+        'events.manifest.json regenerated from DL_EVENTS — re-run tests without ' +
+          'UPDATE_ANALYTICS_MANIFEST to confirm it is in sync.'
+      );
     }
     const actual = readFileSync(MANIFEST_PATH, 'utf8');
     expect(actual).toBe(expected);

--- a/src/tests/utils/analyticsVocabulary.test.ts
+++ b/src/tests/utils/analyticsVocabulary.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  DL_EVENTS,
+  DL_EVENT_NAMES,
+  DL_EVENT_NAME_SET,
+  isKnownDlEvent,
+} from '@/utils/analytics/schemas/events';
+import { eventSchemas } from '@/utils/analytics/schemas';
+
+// Committed manifest = the cross-repo carrier. campaigns-os
+// (campaign-spec/analytics-vocabulary.ts) syncs its copy from this file, so it
+// must stay byte-identical to the DL_EVENTS const. Regenerate after editing the
+// vocabulary with:  UPDATE_ANALYTICS_MANIFEST=1 npm run test -- analyticsVocabulary
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = join(
+  __dirname,
+  '../../utils/analytics/schemas/events.manifest.json'
+);
+
+function buildManifest(): string {
+  return (
+    JSON.stringify(
+      {
+        $comment:
+          'AUTO-GENERATED from src/utils/analytics/schemas/events.ts (DL_EVENTS). ' +
+          'Do not hand-edit. Regenerate: UPDATE_ANALYTICS_MANIFEST=1 npm run test -- analyticsVocabulary',
+        events: DL_EVENTS,
+      },
+      null,
+      2
+    ) + '\n'
+  );
+}
+
+describe('analytics dl_* vocabulary (single source of truth)', () => {
+  it('has no duplicate event names', () => {
+    expect(DL_EVENT_NAMES.length).toBe(DL_EVENT_NAME_SET.size);
+    expect(DL_EVENT_NAMES.length).toBe(DL_EVENTS.length);
+  });
+
+  it('every name is a well-formed dl_* identifier', () => {
+    for (const name of DL_EVENT_NAMES) {
+      expect(name).toMatch(/^dl_[a-z_]+$/);
+    }
+  });
+
+  it('every schema-bearing event is registered in the vocabulary', () => {
+    // Guards the invariant: you cannot add a field schema for an event without
+    // also declaring it in DL_EVENTS. The reverse is allowed (the superset
+    // contains many events that carry no field schema).
+    const schemaKeys = Object.keys(eventSchemas);
+    const missing = schemaKeys.filter(k => !DL_EVENT_NAME_SET.has(k));
+    expect(missing).toEqual([]);
+  });
+
+  it('hasSchema flag matches eventSchemas membership exactly', () => {
+    for (const def of DL_EVENTS) {
+      expect(def.hasSchema).toBe(
+        Object.prototype.hasOwnProperty.call(eventSchemas, def.name)
+      );
+    }
+  });
+
+  it('isKnownDlEvent recognizes vocabulary and rejects unknowns', () => {
+    expect(isKnownDlEvent('dl_purchase')).toBe(true);
+    expect(isKnownDlEvent('purchase')).toBe(false); // the original drift bug
+    expect(isKnownDlEvent('dl_not_a_real_event')).toBe(false);
+  });
+
+  it('committed manifest is in sync with DL_EVENTS', () => {
+    const expected = buildManifest();
+    if (process.env.UPDATE_ANALYTICS_MANIFEST) {
+      writeFileSync(MANIFEST_PATH, expected);
+    }
+    const actual = readFileSync(MANIFEST_PATH, 'utf8');
+    expect(actual).toBe(expected);
+  });
+});

--- a/src/utils/analytics/index.ts
+++ b/src/utils/analytics/index.ts
@@ -374,6 +374,18 @@ export const nextAnalytics = NextAnalytics.getInstance();
 
 // Export types and utilities
 export * from './types';
+// Canonical dl_* event vocabulary — single source of truth for consumers
+export {
+  DL_EVENTS,
+  DL_EVENT_NAMES,
+  DL_EVENT_NAME_SET,
+  isKnownDlEvent,
+} from './schemas/events';
+export type {
+  DlEventName,
+  DlEventCategory,
+  DlEventDefinition,
+} from './schemas/events';
 export { EventValidator } from './validation/EventValidator';
 export { EcommerceEvents } from './events/EcommerceEvents';
 export { UserEvents } from './events/UserEvents';

--- a/src/utils/analytics/index.ts
+++ b/src/utils/analytics/index.ts
@@ -1,6 +1,6 @@
 /**
  * Next Analytics v2 - Clean, Elevar-inspired analytics system
- *
+ * 
  * This is the main entry point for the analytics system.
  * It provides a simple API for tracking events following industry best practices.
  */
@@ -94,7 +94,7 @@ export class NextAnalytics {
     try {
       const urlParams = new URLSearchParams(window.location.search);
       const ignoreParam = urlParams.get('ignore');
-
+      
       if (ignoreParam === 'true') {
         // Set session storage flag
         sessionStorage.setItem('analytics_ignore', 'true');
@@ -152,7 +152,7 @@ export class NextAnalytics {
 
     try {
       const config = useConfigStore.getState();
-
+      
       // Check if analytics is enabled
       if (!config.analytics?.enabled) {
         logger.info('Analytics disabled in configuration');
@@ -189,13 +189,9 @@ export class NextAnalytics {
         this.viewTracker.initialize();
         this.autoListener.initialize();
 
-        logger.info(
-          'Auto-tracking initialized (user data fired first, meta tags processed)'
-        );
+        logger.info('Auto-tracking initialized (user data fired first, meta tags processed)');
       } else {
-        logger.info(
-          'Manual mode - meta tags processed, auto-tracking disabled'
-        );
+        logger.info('Manual mode - meta tags processed, auto-tracking disabled');
       }
 
       // Process any pending events from previous page AFTER everything is initialized
@@ -207,7 +203,7 @@ export class NextAnalytics {
       this.initialized = true;
       logger.info('NextAnalytics initialized successfully', {
         providers: Array.from(this.providers.keys()),
-        mode: config.analytics.mode,
+        mode: config.analytics.mode
       });
     } catch (error) {
       logger.error('Failed to initialize analytics:', error);
@@ -223,10 +219,7 @@ export class NextAnalytics {
    * layer. Each adapter's {@link ProviderAdapter.initialize} hook is awaited so
    * script-loading providers (e.g. NextCampaign) are ready before events flow.
    */
-  private async initializeProviders(
-    config: any,
-    storeName?: string
-  ): Promise<void> {
+  private async initializeProviders(config: any, storeName?: string): Promise<void> {
     const providerConfigs = config.providers ?? {};
     const ctx: ProviderContext = { storeName };
 
@@ -246,7 +239,7 @@ export class NextAnalytics {
       this.providers.set(key, adapter);
       dataLayer.addProvider(adapter);
       logger.info(`${key} adapter initialized`, {
-        blockedEvents: providerConfig.blockedEvents ?? [],
+        blockedEvents: providerConfig.blockedEvents ?? []
       });
     }
   }
@@ -292,9 +285,7 @@ export class NextAnalytics {
   /**
    * Set transform function for events
    */
-  public setTransformFunction(
-    fn: (event: DataLayerEvent) => DataLayerEvent | null
-  ): void {
+  public setTransformFunction(fn: (event: DataLayerEvent) => DataLayerEvent | null): void {
     dataLayer.setTransformFunction(fn);
   }
 
@@ -326,7 +317,7 @@ export class NextAnalytics {
       debugMode: dataLayer.isDebugMode(),
       providers: Array.from(this.providers.keys()),
       eventsTracked: dataLayer.getEventCount(),
-      ignored: this.shouldIgnoreAnalytics(),
+      ignored: this.shouldIgnoreAnalytics()
     };
   }
 
@@ -347,25 +338,15 @@ export class NextAnalytics {
   /**
    * Convenience methods for common events
    */
-  public trackViewItemList(
-    items: (CartItem | EnrichedCartLine | any)[],
-    listId?: string,
-    listName?: string
-  ): void {
-    this.track(
-      EcommerceEvents.createViewItemListEvent(items, listId, listName)
-    );
+  public trackViewItemList(items: (CartItem | EnrichedCartLine | any)[], listId?: string, listName?: string): void {
+    this.track(EcommerceEvents.createViewItemListEvent(items, listId, listName));
   }
 
   public trackViewItem(item: CartItem | EnrichedCartLine | any): void {
     this.track(EcommerceEvents.createViewItemEvent(item));
   }
 
-  public trackAddToCart(
-    item: CartItem | EnrichedCartLine | any,
-    listId?: string,
-    listName?: string
-  ): void {
+  public trackAddToCart(item: CartItem | EnrichedCartLine | any, listId?: string, listName?: string): void {
     this.track(EcommerceEvents.createAddToCartEvent(item, listId, listName));
   }
 
@@ -393,26 +374,11 @@ export const nextAnalytics = NextAnalytics.getInstance();
 
 // Export types and utilities
 export * from './types';
-// Canonical dl_* event vocabulary — single source of truth for consumers
-export {
-  DL_EVENTS,
-  DL_EVENT_NAMES,
-  DL_EVENT_NAME_SET,
-  isKnownDlEvent,
-} from './schemas/events';
-export type {
-  DlEventName,
-  DlEventCategory,
-  DlEventDefinition,
-} from './schemas/events';
 export { EventValidator } from './validation/EventValidator';
 export { EcommerceEvents } from './events/EcommerceEvents';
 export { UserEvents } from './events/UserEvents';
 export { dataLayer } from './DataLayerManager';
-export {
-  MetaTagController,
-  metaTagController,
-} from './tracking/MetaTagController';
+export { MetaTagController, metaTagController } from './tracking/MetaTagController';
 
 // Set up global access for debugging
 if (typeof window !== 'undefined') {

--- a/src/utils/analytics/index.ts
+++ b/src/utils/analytics/index.ts
@@ -1,6 +1,6 @@
 /**
  * Next Analytics v2 - Clean, Elevar-inspired analytics system
- * 
+ *
  * This is the main entry point for the analytics system.
  * It provides a simple API for tracking events following industry best practices.
  */
@@ -94,7 +94,7 @@ export class NextAnalytics {
     try {
       const urlParams = new URLSearchParams(window.location.search);
       const ignoreParam = urlParams.get('ignore');
-      
+
       if (ignoreParam === 'true') {
         // Set session storage flag
         sessionStorage.setItem('analytics_ignore', 'true');
@@ -152,7 +152,7 @@ export class NextAnalytics {
 
     try {
       const config = useConfigStore.getState();
-      
+
       // Check if analytics is enabled
       if (!config.analytics?.enabled) {
         logger.info('Analytics disabled in configuration');
@@ -189,9 +189,13 @@ export class NextAnalytics {
         this.viewTracker.initialize();
         this.autoListener.initialize();
 
-        logger.info('Auto-tracking initialized (user data fired first, meta tags processed)');
+        logger.info(
+          'Auto-tracking initialized (user data fired first, meta tags processed)'
+        );
       } else {
-        logger.info('Manual mode - meta tags processed, auto-tracking disabled');
+        logger.info(
+          'Manual mode - meta tags processed, auto-tracking disabled'
+        );
       }
 
       // Process any pending events from previous page AFTER everything is initialized
@@ -203,7 +207,7 @@ export class NextAnalytics {
       this.initialized = true;
       logger.info('NextAnalytics initialized successfully', {
         providers: Array.from(this.providers.keys()),
-        mode: config.analytics.mode
+        mode: config.analytics.mode,
       });
     } catch (error) {
       logger.error('Failed to initialize analytics:', error);
@@ -219,7 +223,10 @@ export class NextAnalytics {
    * layer. Each adapter's {@link ProviderAdapter.initialize} hook is awaited so
    * script-loading providers (e.g. NextCampaign) are ready before events flow.
    */
-  private async initializeProviders(config: any, storeName?: string): Promise<void> {
+  private async initializeProviders(
+    config: any,
+    storeName?: string
+  ): Promise<void> {
     const providerConfigs = config.providers ?? {};
     const ctx: ProviderContext = { storeName };
 
@@ -239,7 +246,7 @@ export class NextAnalytics {
       this.providers.set(key, adapter);
       dataLayer.addProvider(adapter);
       logger.info(`${key} adapter initialized`, {
-        blockedEvents: providerConfig.blockedEvents ?? []
+        blockedEvents: providerConfig.blockedEvents ?? [],
       });
     }
   }
@@ -285,7 +292,9 @@ export class NextAnalytics {
   /**
    * Set transform function for events
    */
-  public setTransformFunction(fn: (event: DataLayerEvent) => DataLayerEvent | null): void {
+  public setTransformFunction(
+    fn: (event: DataLayerEvent) => DataLayerEvent | null
+  ): void {
     dataLayer.setTransformFunction(fn);
   }
 
@@ -317,7 +326,7 @@ export class NextAnalytics {
       debugMode: dataLayer.isDebugMode(),
       providers: Array.from(this.providers.keys()),
       eventsTracked: dataLayer.getEventCount(),
-      ignored: this.shouldIgnoreAnalytics()
+      ignored: this.shouldIgnoreAnalytics(),
     };
   }
 
@@ -338,15 +347,25 @@ export class NextAnalytics {
   /**
    * Convenience methods for common events
    */
-  public trackViewItemList(items: (CartItem | EnrichedCartLine | any)[], listId?: string, listName?: string): void {
-    this.track(EcommerceEvents.createViewItemListEvent(items, listId, listName));
+  public trackViewItemList(
+    items: (CartItem | EnrichedCartLine | any)[],
+    listId?: string,
+    listName?: string
+  ): void {
+    this.track(
+      EcommerceEvents.createViewItemListEvent(items, listId, listName)
+    );
   }
 
   public trackViewItem(item: CartItem | EnrichedCartLine | any): void {
     this.track(EcommerceEvents.createViewItemEvent(item));
   }
 
-  public trackAddToCart(item: CartItem | EnrichedCartLine | any, listId?: string, listName?: string): void {
+  public trackAddToCart(
+    item: CartItem | EnrichedCartLine | any,
+    listId?: string,
+    listName?: string
+  ): void {
     this.track(EcommerceEvents.createAddToCartEvent(item, listId, listName));
   }
 
@@ -374,11 +393,26 @@ export const nextAnalytics = NextAnalytics.getInstance();
 
 // Export types and utilities
 export * from './types';
+// Canonical dl_* event vocabulary — single source of truth for consumers
+export {
+  DL_EVENTS,
+  DL_EVENT_NAMES,
+  DL_EVENT_NAME_SET,
+  isKnownDlEvent,
+} from './schemas/events';
+export type {
+  DlEventName,
+  DlEventCategory,
+  DlEventDefinition,
+} from './schemas/events';
 export { EventValidator } from './validation/EventValidator';
 export { EcommerceEvents } from './events/EcommerceEvents';
 export { UserEvents } from './events/UserEvents';
 export { dataLayer } from './DataLayerManager';
-export { MetaTagController, metaTagController } from './tracking/MetaTagController';
+export {
+  MetaTagController,
+  metaTagController,
+} from './tracking/MetaTagController';
 
 // Set up global access for debugging
 if (typeof window !== 'undefined') {

--- a/src/utils/analytics/schemas/events.manifest.json
+++ b/src/utils/analytics/schemas/events.manifest.json
@@ -1,0 +1,215 @@
+{
+  "$comment": "AUTO-GENERATED from src/utils/analytics/schemas/events.ts (DL_EVENTS). Do not hand-edit. Regenerate: UPDATE_ANALYTICS_MANIFEST=1 npm run test -- analyticsVocabulary",
+  "events": [
+    {
+      "name": "dl_view_item_list",
+      "category": "ecommerce",
+      "hasSchema": true,
+      "description": "Product list / collection impression"
+    },
+    {
+      "name": "dl_view_item",
+      "category": "ecommerce",
+      "hasSchema": true,
+      "description": "Product detail view"
+    },
+    {
+      "name": "dl_select_item",
+      "category": "ecommerce",
+      "hasSchema": true,
+      "description": "Product clicked from a list"
+    },
+    {
+      "name": "dl_view_search_results",
+      "category": "ecommerce",
+      "hasSchema": true,
+      "description": "Search results viewed"
+    },
+    {
+      "name": "dl_search",
+      "category": "ecommerce",
+      "hasSchema": false,
+      "description": "Search performed (Meta Search)"
+    },
+    {
+      "name": "dl_add_to_cart",
+      "category": "ecommerce",
+      "hasSchema": true,
+      "description": "Item added to cart"
+    },
+    {
+      "name": "dl_remove_from_cart",
+      "category": "ecommerce",
+      "hasSchema": true,
+      "description": "Item removed from cart"
+    },
+    {
+      "name": "dl_add_to_wishlist",
+      "category": "ecommerce",
+      "hasSchema": false,
+      "description": "Item added to wishlist"
+    },
+    {
+      "name": "dl_view_cart",
+      "category": "ecommerce",
+      "hasSchema": true,
+      "description": "Cart viewed"
+    },
+    {
+      "name": "dl_begin_checkout",
+      "category": "ecommerce",
+      "hasSchema": true,
+      "description": "Checkout started"
+    },
+    {
+      "name": "dl_add_shipping_info",
+      "category": "ecommerce",
+      "hasSchema": true,
+      "description": "Shipping info added"
+    },
+    {
+      "name": "dl_add_payment_info",
+      "category": "ecommerce",
+      "hasSchema": true,
+      "description": "Payment info added"
+    },
+    {
+      "name": "dl_purchase",
+      "category": "ecommerce",
+      "hasSchema": true,
+      "description": "Main order purchase"
+    },
+    {
+      "name": "dl_refund",
+      "category": "ecommerce",
+      "hasSchema": false,
+      "description": "Order refunded (adapter-mapped)"
+    },
+    {
+      "name": "dl_view_promotion",
+      "category": "ecommerce",
+      "hasSchema": false,
+      "description": "Promotion impression"
+    },
+    {
+      "name": "dl_select_promotion",
+      "category": "ecommerce",
+      "hasSchema": false,
+      "description": "Promotion clicked"
+    },
+    {
+      "name": "dl_user_data",
+      "category": "user",
+      "hasSchema": true,
+      "description": "User + cart context (fired first)"
+    },
+    {
+      "name": "dl_sign_up",
+      "category": "user",
+      "hasSchema": true,
+      "description": "Account sign-up"
+    },
+    {
+      "name": "dl_login",
+      "category": "user",
+      "hasSchema": true,
+      "description": "Account login"
+    },
+    {
+      "name": "dl_subscribe",
+      "category": "user",
+      "hasSchema": true,
+      "description": "Subscription created"
+    },
+    {
+      "name": "dl_start_trial",
+      "category": "user",
+      "hasSchema": false,
+      "description": "Trial started (Meta StartTrial)"
+    },
+    {
+      "name": "dl_viewed_upsell",
+      "category": "upsell",
+      "hasSchema": true,
+      "description": "Upsell offer viewed"
+    },
+    {
+      "name": "dl_accepted_upsell",
+      "category": "upsell",
+      "hasSchema": true,
+      "description": "Upsell accepted"
+    },
+    {
+      "name": "dl_skipped_upsell",
+      "category": "upsell",
+      "hasSchema": true,
+      "description": "Upsell skipped"
+    },
+    {
+      "name": "dl_upsell_purchase",
+      "category": "upsell",
+      "hasSchema": true,
+      "description": "Accepted upsell in GA4 purchase format"
+    },
+    {
+      "name": "dl_cart_updated",
+      "category": "cart",
+      "hasSchema": false,
+      "description": "Cart contents changed"
+    },
+    {
+      "name": "dl_package_swapped",
+      "category": "cart",
+      "hasSchema": false,
+      "description": "Selected package swapped"
+    },
+    {
+      "name": "dl_page_view",
+      "category": "navigation",
+      "hasSchema": false,
+      "description": "Page view (SPA-aware)"
+    },
+    {
+      "name": "dl_route_changed",
+      "category": "navigation",
+      "hasSchema": false,
+      "description": "Client-side route change"
+    },
+    {
+      "name": "dl_scroll_depth",
+      "category": "engagement",
+      "hasSchema": false,
+      "description": "Scroll-depth milestone"
+    },
+    {
+      "name": "dl_exit_intent_shown",
+      "category": "engagement",
+      "hasSchema": false,
+      "description": "Exit-intent popup shown"
+    },
+    {
+      "name": "dl_exit_intent_accepted",
+      "category": "engagement",
+      "hasSchema": false,
+      "description": "Exit-intent offer accepted"
+    },
+    {
+      "name": "dl_exit_intent_dismissed",
+      "category": "engagement",
+      "hasSchema": false,
+      "description": "Exit-intent popup dismissed"
+    },
+    {
+      "name": "dl_exit_intent_closed",
+      "category": "engagement",
+      "hasSchema": false,
+      "description": "Exit-intent popup closed"
+    },
+    {
+      "name": "dl_exit_intent_action",
+      "category": "engagement",
+      "hasSchema": false,
+      "description": "Exit-intent custom action"
+    }
+  ]
+}

--- a/src/utils/analytics/schemas/events.ts
+++ b/src/utils/analytics/schemas/events.ts
@@ -29,7 +29,15 @@ export type DlEventCategory =
   | 'engagement';
 
 export interface DlEventDefinition {
-  /** Exact dataLayer event name the SDK pushes — matched verbatim by `blockedEvents`. */
+  /**
+   * Exact dataLayer event name the SDK pushes — matched verbatim by
+   * `blockedEvents`. Kept as `string` (not the `DlEventName` union) to avoid a
+   * circular self-reference: `DlEventName` is derived FROM `DL_EVENTS`, which is
+   * `satisfies readonly DlEventDefinition[]`. Validity of each name is instead
+   * enforced at test time — see the emit-site drift scan in
+   * `src/tests/utils/analyticsVocabulary.test.ts`, which fails on a name that no
+   * source site actually emits (catching typos a `string` type cannot).
+   */
   name: string;
   /** Coarse grouping for picker UIs and docs. */
   category: DlEventCategory;

--- a/src/utils/analytics/schemas/events.ts
+++ b/src/utils/analytics/schemas/events.ts
@@ -1,0 +1,285 @@
+// Canonical `dl_*` analytics event vocabulary — the SINGLE SOURCE OF TRUTH.
+//
+// Why this file exists
+// --------------------
+// The SDK fires/handles ~35 distinct `dl_*` dataLayer events, but their names
+// historically lived scattered across `events/`, `tracking/AutoEventListener.ts`,
+// and the provider adapters. Consumers that need the list — the Map Builder's
+// blocked-events picker and the campaign-spec `AnalyticsContractShape` validator —
+// were forced to hardcode their own copies, which drift. (A hardcoded
+// `blockedEvents:['purchase']` was a silent no-op against the real `dl_purchase`.)
+//
+// This module is the one authoritative enumeration. `eventSchemas` in
+// ./index.ts defines field-level validation for the subset that carries one
+// (`hasSchema: true`); this file enumerates the FULL firable vocabulary, because
+// `blockedEvents` matches by exact `event.event` name against EVERY event that
+// passes through the DataLayerManager (see ProviderAdapter.shouldTrack) — so the
+// blockable/known vocabulary is the superset, not just the schema'd events.
+//
+// Downstream (campaigns-os `campaign-spec/analytics-vocabulary.ts`) syncs from the
+// generated `analytics-events.json` manifest emitted off this const. Keep this the
+// edit point; add a new event here when the SDK starts firing one.
+
+export type DlEventCategory =
+  | 'ecommerce'
+  | 'user'
+  | 'upsell'
+  | 'cart'
+  | 'navigation'
+  | 'engagement';
+
+export interface DlEventDefinition {
+  /** Exact dataLayer event name the SDK pushes — matched verbatim by `blockedEvents`. */
+  name: string;
+  /** Coarse grouping for picker UIs and docs. */
+  category: DlEventCategory;
+  /** True when ./index.ts `eventSchemas` defines field-level validation for it. */
+  hasSchema: boolean;
+  /** One-line human label for pickers and generated docs. */
+  description: string;
+}
+
+/**
+ * The canonical vocabulary. Order is category-grouped for readable pickers.
+ * `as const` makes {@link DlEventName} a precise literal union; `satisfies`
+ * enforces the shape without widening the literals.
+ */
+export const DL_EVENTS = [
+  // — ecommerce (GA4 standard) —
+  {
+    name: 'dl_view_item_list',
+    category: 'ecommerce',
+    hasSchema: true,
+    description: 'Product list / collection impression',
+  },
+  {
+    name: 'dl_view_item',
+    category: 'ecommerce',
+    hasSchema: true,
+    description: 'Product detail view',
+  },
+  {
+    name: 'dl_select_item',
+    category: 'ecommerce',
+    hasSchema: true,
+    description: 'Product clicked from a list',
+  },
+  {
+    name: 'dl_view_search_results',
+    category: 'ecommerce',
+    hasSchema: true,
+    description: 'Search results viewed',
+  },
+  {
+    name: 'dl_search',
+    category: 'ecommerce',
+    hasSchema: false,
+    description: 'Search performed (Meta Search)',
+  },
+  {
+    name: 'dl_add_to_cart',
+    category: 'ecommerce',
+    hasSchema: true,
+    description: 'Item added to cart',
+  },
+  {
+    name: 'dl_remove_from_cart',
+    category: 'ecommerce',
+    hasSchema: true,
+    description: 'Item removed from cart',
+  },
+  {
+    name: 'dl_add_to_wishlist',
+    category: 'ecommerce',
+    hasSchema: false,
+    description: 'Item added to wishlist',
+  },
+  {
+    name: 'dl_view_cart',
+    category: 'ecommerce',
+    hasSchema: true,
+    description: 'Cart viewed',
+  },
+  {
+    name: 'dl_begin_checkout',
+    category: 'ecommerce',
+    hasSchema: true,
+    description: 'Checkout started',
+  },
+  {
+    name: 'dl_add_shipping_info',
+    category: 'ecommerce',
+    hasSchema: true,
+    description: 'Shipping info added',
+  },
+  {
+    name: 'dl_add_payment_info',
+    category: 'ecommerce',
+    hasSchema: true,
+    description: 'Payment info added',
+  },
+  {
+    name: 'dl_purchase',
+    category: 'ecommerce',
+    hasSchema: true,
+    description: 'Main order purchase',
+  },
+  {
+    name: 'dl_refund',
+    category: 'ecommerce',
+    hasSchema: false,
+    description: 'Order refunded (adapter-mapped)',
+  },
+  {
+    name: 'dl_view_promotion',
+    category: 'ecommerce',
+    hasSchema: false,
+    description: 'Promotion impression',
+  },
+  {
+    name: 'dl_select_promotion',
+    category: 'ecommerce',
+    hasSchema: false,
+    description: 'Promotion clicked',
+  },
+
+  // — user / identity —
+  {
+    name: 'dl_user_data',
+    category: 'user',
+    hasSchema: true,
+    description: 'User + cart context (fired first)',
+  },
+  {
+    name: 'dl_sign_up',
+    category: 'user',
+    hasSchema: true,
+    description: 'Account sign-up',
+  },
+  {
+    name: 'dl_login',
+    category: 'user',
+    hasSchema: true,
+    description: 'Account login',
+  },
+  {
+    name: 'dl_subscribe',
+    category: 'user',
+    hasSchema: true,
+    description: 'Subscription created',
+  },
+  {
+    name: 'dl_start_trial',
+    category: 'user',
+    hasSchema: false,
+    description: 'Trial started (Meta StartTrial)',
+  },
+
+  // — upsell (post-purchase) —
+  {
+    name: 'dl_viewed_upsell',
+    category: 'upsell',
+    hasSchema: true,
+    description: 'Upsell offer viewed',
+  },
+  {
+    name: 'dl_accepted_upsell',
+    category: 'upsell',
+    hasSchema: true,
+    description: 'Upsell accepted',
+  },
+  {
+    name: 'dl_skipped_upsell',
+    category: 'upsell',
+    hasSchema: true,
+    description: 'Upsell skipped',
+  },
+  {
+    name: 'dl_upsell_purchase',
+    category: 'upsell',
+    hasSchema: true,
+    description: 'Accepted upsell in GA4 purchase format',
+  },
+
+  // — cart lifecycle —
+  {
+    name: 'dl_cart_updated',
+    category: 'cart',
+    hasSchema: false,
+    description: 'Cart contents changed',
+  },
+  {
+    name: 'dl_package_swapped',
+    category: 'cart',
+    hasSchema: false,
+    description: 'Selected package swapped',
+  },
+
+  // — navigation —
+  {
+    name: 'dl_page_view',
+    category: 'navigation',
+    hasSchema: false,
+    description: 'Page view (SPA-aware)',
+  },
+  {
+    name: 'dl_route_changed',
+    category: 'navigation',
+    hasSchema: false,
+    description: 'Client-side route change',
+  },
+
+  // — engagement / behavior —
+  {
+    name: 'dl_scroll_depth',
+    category: 'engagement',
+    hasSchema: false,
+    description: 'Scroll-depth milestone',
+  },
+  {
+    name: 'dl_exit_intent_shown',
+    category: 'engagement',
+    hasSchema: false,
+    description: 'Exit-intent popup shown',
+  },
+  {
+    name: 'dl_exit_intent_accepted',
+    category: 'engagement',
+    hasSchema: false,
+    description: 'Exit-intent offer accepted',
+  },
+  {
+    name: 'dl_exit_intent_dismissed',
+    category: 'engagement',
+    hasSchema: false,
+    description: 'Exit-intent popup dismissed',
+  },
+  {
+    name: 'dl_exit_intent_closed',
+    category: 'engagement',
+    hasSchema: false,
+    description: 'Exit-intent popup closed',
+  },
+  {
+    name: 'dl_exit_intent_action',
+    category: 'engagement',
+    hasSchema: false,
+    description: 'Exit-intent custom action',
+  },
+] as const satisfies readonly DlEventDefinition[];
+
+/** Precise literal union of every canonical event name. */
+export type DlEventName = (typeof DL_EVENTS)[number]['name'];
+
+/** Flat list of canonical event names — what pickers and validators iterate. */
+export const DL_EVENT_NAMES: readonly DlEventName[] = DL_EVENTS.map(
+  e => e.name
+);
+
+/** O(1) membership set for validation. */
+export const DL_EVENT_NAME_SET: ReadonlySet<string> = new Set(DL_EVENT_NAMES);
+
+/** True when `name` is a known canonical `dl_*` event. */
+export function isKnownDlEvent(name: string): name is DlEventName {
+  return DL_EVENT_NAME_SET.has(name);
+}

--- a/src/utils/analytics/schemas/index.ts
+++ b/src/utils/analytics/schemas/index.ts
@@ -1,5 +1,9 @@
 // Event schema types and definitions for analytics v2
 
+// Canonical dl_* event vocabulary (the full firable superset). `eventSchemas`
+// below defines field-level validation for the subset that carries one.
+export * from './events';
+
 export interface ProductSchema {
   item_id: string;
   item_name: string;

--- a/src/utils/analytics/schemas/index.ts
+++ b/src/utils/analytics/schemas/index.ts
@@ -1,9 +1,5 @@
 // Event schema types and definitions for analytics v2
 
-// Canonical dl_* event vocabulary (the full firable superset). `eventSchemas`
-// below defines field-level validation for the subset that carries one.
-export * from './events';
-
 export interface ProductSchema {
   item_id: string;
   item_name: string;
@@ -96,7 +92,7 @@ const userPropertiesFields: Record<string, FieldDefinition> = {
   customer_address_zip: { type: 'string' },
   customer_order_count: { type: 'number' },
   customer_total_spent: { type: 'number' },
-  customer_tags: { type: 'string' },
+  customer_tags: { type: 'string' }
 };
 
 const productFields: Record<string, FieldDefinition> = {
@@ -119,7 +115,7 @@ const productFields: Record<string, FieldDefinition> = {
   item_image: { type: 'string' },
   location_id: { type: 'string' },
   price: { type: 'number' },
-  quantity: { type: 'number' },
+  quantity: { type: 'number' }
 };
 
 const ecommerceWithItemsFields: Record<string, FieldDefinition> = {
@@ -130,9 +126,9 @@ const ecommerceWithItemsFields: Record<string, FieldDefinition> = {
     type: 'array',
     items: {
       type: 'object',
-      properties: productFields,
-    },
-  },
+      properties: productFields
+    }
+  }
 };
 
 const ecommerceWithImpressionsFields: Record<string, FieldDefinition> = {
@@ -142,9 +138,9 @@ const ecommerceWithImpressionsFields: Record<string, FieldDefinition> = {
     type: 'array',
     items: {
       type: 'object',
-      properties: productFields,
-    },
-  },
+      properties: productFields
+    }
+  }
 };
 
 // Event schemas definitions
@@ -156,7 +152,7 @@ export const eventSchemas: Record<string, EventSchema> = {
       user_properties: {
         type: 'object',
         required: true,
-        properties: userPropertiesFields,
+        properties: userPropertiesFields
       },
       ecommerce: {
         type: 'object',
@@ -167,12 +163,12 @@ export const eventSchemas: Record<string, EventSchema> = {
             type: 'array',
             items: {
               type: 'object',
-              properties: productFields,
-            },
-          },
-        },
-      },
-    },
+              properties: productFields
+            }
+          }
+        }
+      }
+    }
   },
 
   dl_sign_up: {
@@ -181,10 +177,10 @@ export const eventSchemas: Record<string, EventSchema> = {
       event: { type: 'string', required: true },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
+        properties: userPropertiesFields
       },
-      method: { type: 'string' },
-    },
+      method: { type: 'string' }
+    }
   },
 
   dl_login: {
@@ -193,10 +189,10 @@ export const eventSchemas: Record<string, EventSchema> = {
       event: { type: 'string', required: true },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
+        properties: userPropertiesFields
       },
-      method: { type: 'string' },
-    },
+      method: { type: 'string' }
+    }
   },
 
   dl_view_item_list: {
@@ -215,16 +211,16 @@ export const eventSchemas: Record<string, EventSchema> = {
             type: 'array',
             items: {
               type: 'object',
-              properties: productFields,
-            },
-          },
-        },
+              properties: productFields
+            }
+          }
+        }
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   dl_view_search_results: {
@@ -242,16 +238,16 @@ export const eventSchemas: Record<string, EventSchema> = {
             type: 'array',
             items: {
               type: 'object',
-              properties: productFields,
-            },
-          },
-        },
+              properties: productFields
+            }
+          }
+        }
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   dl_select_item: {
@@ -264,14 +260,14 @@ export const eventSchemas: Record<string, EventSchema> = {
         properties: {
           ...ecommerceWithItemsFields,
           item_list_id: { type: 'string' },
-          item_list_name: { type: 'string' },
-        },
+          item_list_name: { type: 'string' }
+        }
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   dl_view_item: {
@@ -281,13 +277,13 @@ export const eventSchemas: Record<string, EventSchema> = {
       ecommerce: {
         type: 'object',
         required: true,
-        properties: ecommerceWithItemsFields,
+        properties: ecommerceWithItemsFields
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   dl_add_to_cart: {
@@ -297,13 +293,13 @@ export const eventSchemas: Record<string, EventSchema> = {
       ecommerce: {
         type: 'object',
         required: true,
-        properties: ecommerceWithItemsFields,
+        properties: ecommerceWithItemsFields
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   dl_remove_from_cart: {
@@ -313,13 +309,13 @@ export const eventSchemas: Record<string, EventSchema> = {
       ecommerce: {
         type: 'object',
         required: true,
-        properties: ecommerceWithItemsFields,
+        properties: ecommerceWithItemsFields
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   dl_view_cart: {
@@ -329,13 +325,13 @@ export const eventSchemas: Record<string, EventSchema> = {
       ecommerce: {
         type: 'object',
         required: true,
-        properties: ecommerceWithItemsFields,
+        properties: ecommerceWithItemsFields
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   dl_begin_checkout: {
@@ -348,14 +344,14 @@ export const eventSchemas: Record<string, EventSchema> = {
         properties: {
           ...ecommerceWithItemsFields,
           checkout_id: { type: 'string' },
-          checkout_step: { type: 'number' },
-        },
+          checkout_step: { type: 'number' }
+        }
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   dl_add_shipping_info: {
@@ -367,15 +363,15 @@ export const eventSchemas: Record<string, EventSchema> = {
         required: true,
         properties: {
           ...ecommerceWithItemsFields,
-          shipping_tier: { type: 'string' },
-        },
+          shipping_tier: { type: 'string' }
+        }
       },
       shipping_tier: { type: 'string' },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   dl_add_payment_info: {
@@ -387,15 +383,15 @@ export const eventSchemas: Record<string, EventSchema> = {
         required: true,
         properties: {
           ...ecommerceWithItemsFields,
-          payment_type: { type: 'string' },
-        },
+          payment_type: { type: 'string' }
+        }
       },
       payment_type: { type: 'string' },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   dl_purchase: {
@@ -411,14 +407,14 @@ export const eventSchemas: Record<string, EventSchema> = {
           affiliation: { type: 'string' },
           tax: { type: 'number' },
           shipping: { type: 'number' },
-          discount: { type: 'number' },
-        },
+          discount: { type: 'number' }
+        }
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   dl_subscribe: {
@@ -430,14 +426,14 @@ export const eventSchemas: Record<string, EventSchema> = {
         properties: {
           ...ecommerceWithItemsFields,
           subscription_id: { type: 'string' },
-          subscription_status: { type: 'string' },
-        },
+          subscription_status: { type: 'string' }
+        }
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
+        properties: userPropertiesFields
+      }
+    }
   },
 
   // Upsell events
@@ -453,10 +449,10 @@ export const eventSchemas: Record<string, EventSchema> = {
           package_id: { type: 'string', required: true },
           package_name: { type: 'string', required: true },
           price: { type: 'number' },
-          currency: { type: 'string' },
-        },
-      },
-    },
+          currency: { type: 'string' }
+        }
+      }
+    }
   },
 
   dl_accepted_upsell: {
@@ -472,10 +468,10 @@ export const eventSchemas: Record<string, EventSchema> = {
           package_name: { type: 'string' },
           quantity: { type: 'number' },
           value: { type: 'number', required: true },
-          currency: { type: 'string' },
-        },
-      },
-    },
+          currency: { type: 'string' }
+        }
+      }
+    }
   },
 
   dl_skipped_upsell: {
@@ -488,10 +484,10 @@ export const eventSchemas: Record<string, EventSchema> = {
         required: true,
         properties: {
           package_id: { type: 'string' },
-          package_name: { type: 'string' },
-        },
-      },
-    },
+          package_name: { type: 'string' }
+        }
+      }
+    }
   },
 
   // Accepted upsell in GA4 purchase format (counterpart to dl_accepted_upsell).
@@ -507,8 +503,8 @@ export const eventSchemas: Record<string, EventSchema> = {
           transaction_id: { type: 'string', required: true },
           affiliation: { type: 'string' },
           tax: { type: 'number' },
-          shipping: { type: 'number' },
-        },
+          shipping: { type: 'number' }
+        }
       },
       upsell_metadata: {
         type: 'object',
@@ -516,29 +512,22 @@ export const eventSchemas: Record<string, EventSchema> = {
           original_order_id: { type: 'string' },
           upsell_number: { type: 'number' },
           package_id: { type: 'string' },
-          package_name: { type: 'string' },
-        },
+          package_name: { type: 'string' }
+        }
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields,
-      },
-    },
-  },
+        properties: userPropertiesFields
+      }
+    }
+  }
 };
 
 // Validation function
-export function validateEventSchema(
-  eventData: any,
-  schema: EventSchema
-): { valid: boolean; errors: string[] } {
+export function validateEventSchema(eventData: any, schema: EventSchema): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
 
-  function validateField(
-    value: any,
-    fieldDef: FieldDefinition,
-    path: string
-  ): void {
+  function validateField(value: any, fieldDef: FieldDefinition, path: string): void {
     // Check if required field is missing
     if (fieldDef.required && (value === undefined || value === null)) {
       errors.push(`Missing required field: ${path}`);
@@ -553,17 +542,13 @@ export function validateEventSchema(
     // Validate type
     const actualType = Array.isArray(value) ? 'array' : typeof value;
     if (actualType !== fieldDef.type) {
-      errors.push(
-        `Invalid type for ${path}: expected ${fieldDef.type}, got ${actualType}`
-      );
+      errors.push(`Invalid type for ${path}: expected ${fieldDef.type}, got ${actualType}`);
       return;
     }
 
     // Validate enum values
     if (fieldDef.enum && !fieldDef.enum.includes(value)) {
-      errors.push(
-        `Invalid value for ${path}: must be one of ${fieldDef.enum.join(', ')}`
-      );
+      errors.push(`Invalid value for ${path}: must be one of ${fieldDef.enum.join(', ')}`);
     }
 
     // Validate object properties
@@ -588,7 +573,7 @@ export function validateEventSchema(
 
   return {
     valid: errors.length === 0,
-    errors,
+    errors
   };
 }
 
@@ -596,3 +581,4 @@ export function validateEventSchema(
 export function getEventSchema(eventName: string): EventSchema | undefined {
   return eventSchemas[eventName];
 }
+

--- a/src/utils/analytics/schemas/index.ts
+++ b/src/utils/analytics/schemas/index.ts
@@ -1,5 +1,9 @@
 // Event schema types and definitions for analytics v2
 
+// Canonical dl_* event vocabulary (the full firable superset). `eventSchemas`
+// below defines field-level validation for the subset that carries one.
+export * from './events';
+
 export interface ProductSchema {
   item_id: string;
   item_name: string;
@@ -92,7 +96,7 @@ const userPropertiesFields: Record<string, FieldDefinition> = {
   customer_address_zip: { type: 'string' },
   customer_order_count: { type: 'number' },
   customer_total_spent: { type: 'number' },
-  customer_tags: { type: 'string' }
+  customer_tags: { type: 'string' },
 };
 
 const productFields: Record<string, FieldDefinition> = {
@@ -115,7 +119,7 @@ const productFields: Record<string, FieldDefinition> = {
   item_image: { type: 'string' },
   location_id: { type: 'string' },
   price: { type: 'number' },
-  quantity: { type: 'number' }
+  quantity: { type: 'number' },
 };
 
 const ecommerceWithItemsFields: Record<string, FieldDefinition> = {
@@ -126,9 +130,9 @@ const ecommerceWithItemsFields: Record<string, FieldDefinition> = {
     type: 'array',
     items: {
       type: 'object',
-      properties: productFields
-    }
-  }
+      properties: productFields,
+    },
+  },
 };
 
 const ecommerceWithImpressionsFields: Record<string, FieldDefinition> = {
@@ -138,9 +142,9 @@ const ecommerceWithImpressionsFields: Record<string, FieldDefinition> = {
     type: 'array',
     items: {
       type: 'object',
-      properties: productFields
-    }
-  }
+      properties: productFields,
+    },
+  },
 };
 
 // Event schemas definitions
@@ -152,7 +156,7 @@ export const eventSchemas: Record<string, EventSchema> = {
       user_properties: {
         type: 'object',
         required: true,
-        properties: userPropertiesFields
+        properties: userPropertiesFields,
       },
       ecommerce: {
         type: 'object',
@@ -163,12 +167,12 @@ export const eventSchemas: Record<string, EventSchema> = {
             type: 'array',
             items: {
               type: 'object',
-              properties: productFields
-            }
-          }
-        }
-      }
-    }
+              properties: productFields,
+            },
+          },
+        },
+      },
+    },
   },
 
   dl_sign_up: {
@@ -177,10 +181,10 @@ export const eventSchemas: Record<string, EventSchema> = {
       event: { type: 'string', required: true },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
+        properties: userPropertiesFields,
       },
-      method: { type: 'string' }
-    }
+      method: { type: 'string' },
+    },
   },
 
   dl_login: {
@@ -189,10 +193,10 @@ export const eventSchemas: Record<string, EventSchema> = {
       event: { type: 'string', required: true },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
+        properties: userPropertiesFields,
       },
-      method: { type: 'string' }
-    }
+      method: { type: 'string' },
+    },
   },
 
   dl_view_item_list: {
@@ -211,16 +215,16 @@ export const eventSchemas: Record<string, EventSchema> = {
             type: 'array',
             items: {
               type: 'object',
-              properties: productFields
-            }
-          }
-        }
+              properties: productFields,
+            },
+          },
+        },
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   dl_view_search_results: {
@@ -238,16 +242,16 @@ export const eventSchemas: Record<string, EventSchema> = {
             type: 'array',
             items: {
               type: 'object',
-              properties: productFields
-            }
-          }
-        }
+              properties: productFields,
+            },
+          },
+        },
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   dl_select_item: {
@@ -260,14 +264,14 @@ export const eventSchemas: Record<string, EventSchema> = {
         properties: {
           ...ecommerceWithItemsFields,
           item_list_id: { type: 'string' },
-          item_list_name: { type: 'string' }
-        }
+          item_list_name: { type: 'string' },
+        },
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   dl_view_item: {
@@ -277,13 +281,13 @@ export const eventSchemas: Record<string, EventSchema> = {
       ecommerce: {
         type: 'object',
         required: true,
-        properties: ecommerceWithItemsFields
+        properties: ecommerceWithItemsFields,
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   dl_add_to_cart: {
@@ -293,13 +297,13 @@ export const eventSchemas: Record<string, EventSchema> = {
       ecommerce: {
         type: 'object',
         required: true,
-        properties: ecommerceWithItemsFields
+        properties: ecommerceWithItemsFields,
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   dl_remove_from_cart: {
@@ -309,13 +313,13 @@ export const eventSchemas: Record<string, EventSchema> = {
       ecommerce: {
         type: 'object',
         required: true,
-        properties: ecommerceWithItemsFields
+        properties: ecommerceWithItemsFields,
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   dl_view_cart: {
@@ -325,13 +329,13 @@ export const eventSchemas: Record<string, EventSchema> = {
       ecommerce: {
         type: 'object',
         required: true,
-        properties: ecommerceWithItemsFields
+        properties: ecommerceWithItemsFields,
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   dl_begin_checkout: {
@@ -344,14 +348,14 @@ export const eventSchemas: Record<string, EventSchema> = {
         properties: {
           ...ecommerceWithItemsFields,
           checkout_id: { type: 'string' },
-          checkout_step: { type: 'number' }
-        }
+          checkout_step: { type: 'number' },
+        },
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   dl_add_shipping_info: {
@@ -363,15 +367,15 @@ export const eventSchemas: Record<string, EventSchema> = {
         required: true,
         properties: {
           ...ecommerceWithItemsFields,
-          shipping_tier: { type: 'string' }
-        }
+          shipping_tier: { type: 'string' },
+        },
       },
       shipping_tier: { type: 'string' },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   dl_add_payment_info: {
@@ -383,15 +387,15 @@ export const eventSchemas: Record<string, EventSchema> = {
         required: true,
         properties: {
           ...ecommerceWithItemsFields,
-          payment_type: { type: 'string' }
-        }
+          payment_type: { type: 'string' },
+        },
       },
       payment_type: { type: 'string' },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   dl_purchase: {
@@ -407,14 +411,14 @@ export const eventSchemas: Record<string, EventSchema> = {
           affiliation: { type: 'string' },
           tax: { type: 'number' },
           shipping: { type: 'number' },
-          discount: { type: 'number' }
-        }
+          discount: { type: 'number' },
+        },
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   dl_subscribe: {
@@ -426,14 +430,14 @@ export const eventSchemas: Record<string, EventSchema> = {
         properties: {
           ...ecommerceWithItemsFields,
           subscription_id: { type: 'string' },
-          subscription_status: { type: 'string' }
-        }
+          subscription_status: { type: 'string' },
+        },
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
+        properties: userPropertiesFields,
+      },
+    },
   },
 
   // Upsell events
@@ -449,10 +453,10 @@ export const eventSchemas: Record<string, EventSchema> = {
           package_id: { type: 'string', required: true },
           package_name: { type: 'string', required: true },
           price: { type: 'number' },
-          currency: { type: 'string' }
-        }
-      }
-    }
+          currency: { type: 'string' },
+        },
+      },
+    },
   },
 
   dl_accepted_upsell: {
@@ -468,10 +472,10 @@ export const eventSchemas: Record<string, EventSchema> = {
           package_name: { type: 'string' },
           quantity: { type: 'number' },
           value: { type: 'number', required: true },
-          currency: { type: 'string' }
-        }
-      }
-    }
+          currency: { type: 'string' },
+        },
+      },
+    },
   },
 
   dl_skipped_upsell: {
@@ -484,10 +488,10 @@ export const eventSchemas: Record<string, EventSchema> = {
         required: true,
         properties: {
           package_id: { type: 'string' },
-          package_name: { type: 'string' }
-        }
-      }
-    }
+          package_name: { type: 'string' },
+        },
+      },
+    },
   },
 
   // Accepted upsell in GA4 purchase format (counterpart to dl_accepted_upsell).
@@ -503,8 +507,8 @@ export const eventSchemas: Record<string, EventSchema> = {
           transaction_id: { type: 'string', required: true },
           affiliation: { type: 'string' },
           tax: { type: 'number' },
-          shipping: { type: 'number' }
-        }
+          shipping: { type: 'number' },
+        },
       },
       upsell_metadata: {
         type: 'object',
@@ -512,22 +516,29 @@ export const eventSchemas: Record<string, EventSchema> = {
           original_order_id: { type: 'string' },
           upsell_number: { type: 'number' },
           package_id: { type: 'string' },
-          package_name: { type: 'string' }
-        }
+          package_name: { type: 'string' },
+        },
       },
       user_properties: {
         type: 'object',
-        properties: userPropertiesFields
-      }
-    }
-  }
+        properties: userPropertiesFields,
+      },
+    },
+  },
 };
 
 // Validation function
-export function validateEventSchema(eventData: any, schema: EventSchema): { valid: boolean; errors: string[] } {
+export function validateEventSchema(
+  eventData: any,
+  schema: EventSchema
+): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
 
-  function validateField(value: any, fieldDef: FieldDefinition, path: string): void {
+  function validateField(
+    value: any,
+    fieldDef: FieldDefinition,
+    path: string
+  ): void {
     // Check if required field is missing
     if (fieldDef.required && (value === undefined || value === null)) {
       errors.push(`Missing required field: ${path}`);
@@ -542,13 +553,17 @@ export function validateEventSchema(eventData: any, schema: EventSchema): { vali
     // Validate type
     const actualType = Array.isArray(value) ? 'array' : typeof value;
     if (actualType !== fieldDef.type) {
-      errors.push(`Invalid type for ${path}: expected ${fieldDef.type}, got ${actualType}`);
+      errors.push(
+        `Invalid type for ${path}: expected ${fieldDef.type}, got ${actualType}`
+      );
       return;
     }
 
     // Validate enum values
     if (fieldDef.enum && !fieldDef.enum.includes(value)) {
-      errors.push(`Invalid value for ${path}: must be one of ${fieldDef.enum.join(', ')}`);
+      errors.push(
+        `Invalid value for ${path}: must be one of ${fieldDef.enum.join(', ')}`
+      );
     }
 
     // Validate object properties
@@ -573,7 +588,7 @@ export function validateEventSchema(eventData: any, schema: EventSchema): { vali
 
   return {
     valid: errors.length === 0,
-    errors
+    errors,
   };
 }
 
@@ -581,4 +596,3 @@ export function validateEventSchema(eventData: any, schema: EventSchema): { vali
 export function getEventSchema(eventName: string): EventSchema | undefined {
   return eventSchemas[eventName];
 }
-


### PR DESCRIPTION
## Summary

Adds a single, canonical, **exported** list of the `dl_*` dataLayer event names this SDK emits — `DL_EVENTS` (typed) plus a generated `events.manifest.json`. Today those names are spread across `events/`, `tracking/AutoEventListener.ts`, and the provider adapters, with no exported enumeration, so anything outside the SDK that needs to know "which analytics events can this SDK fire?" hardcodes its own copy and drifts out of sync.

**Additive and behavior-neutral** — no runtime/dispatch changes, no event renames. This only *publishes* what the SDK already emits.

## What's in it

- **`src/utils/analytics/schemas/events.ts`** — `DL_EVENTS`: the full list of firable `dl_*` events (~35), each tagged with a `category` and `hasSchema`. Plus `DlEventName` (a literal union), `DL_EVENT_NAMES`, `DL_EVENT_NAME_SET`, and `isKnownDlEvent()`. Re-exported from the analytics index.
- **`events.manifest.json`** — a generated JSON copy of the list, for non-TypeScript / cross-repo consumers. Built via `npm run analytics:manifest`.
- **`analyticsVocabulary.test.ts`** — keeps the manifest in sync with `DL_EVENTS` and enforces two invariants: no duplicate names, and every event that has a field-validation schema in `eventSchemas` is also present in `DL_EVENTS` (so adding a schema'd event without listing it fails CI).

## Why the list is the full emit set, not just the schema'd events

`eventSchemas` only covers the ~19 events that carry field-level validation, but the SDK fires more than that (auto page/route/cart events, exit-intent, adapter-mapped events like `dl_refund` / `dl_add_to_wishlist`). Provider `blockedEvents` is matched by **exact `event.event` name** against everything dispatched (`ProviderAdapter.shouldTrack`), so the published list has to be the complete emit set — otherwise a legitimately-blockable event (e.g. `dl_page_view`) would look "unknown" to consumers.

## Verification

- `npm run type-check` — clean
- `npx vitest run src/tests/utils` — 169 pass (incl. 6 new)
- `npm run analytics:manifest` regenerates byte-identical (no diff)

## Context (why this is being asked for)

A downstream campaign-tooling build recently shipped a provider config that blocked `"purchase"` — which silently did nothing, because the SDK fires `dl_purchase`. The fix that prevents that whole class of bug is to let downstream tools validate against the SDK's real event names instead of guessing them. This PR is the SDK-side half: it just exposes the names. The consuming tools live in other repos and don't require any further SDK changes. Happy to adjust naming/placement/export surface to whatever fits SDK conventions best.